### PR TITLE
clang requires gcc runtime libraries

### DIFF
--- a/build/clang/build-13.sh
+++ b/build/clang/build-13.sh
@@ -37,7 +37,10 @@ set_patchdir patches-$MAJVER
 # Using the = prefix to require the specific matching version of llvm
 BUILD_DEPENDS_IPS="=ooce/developer/llvm-$MAJVER@$VER"
 
-RUN_DEPENDS_IPS="=ooce/developer/llvm-$MAJVER@$MINVER"
+RUN_DEPENDS_IPS="
+    =ooce/developer/llvm-$MAJVER@$MINVER
+    developer/gcc$GCCVER
+"
 
 OPREFIX=$PREFIX
 PREFIX+=/llvm-$MAJVER

--- a/build/clang/build-14.sh
+++ b/build/clang/build-14.sh
@@ -40,7 +40,10 @@ set_patchdir patches-$MAJVER
 # Using the = prefix to require the specific matching version of llvm
 BUILD_DEPENDS_IPS="=ooce/developer/llvm-$MAJVER@$VER"
 
-RUN_DEPENDS_IPS="=ooce/developer/llvm-$MAJVER@$MINVER"
+RUN_DEPENDS_IPS="
+    =ooce/developer/llvm-$MAJVER@$MINVER
+    developer/gcc$GCCVER
+"
 
 OPREFIX=$PREFIX
 PREFIX+=/llvm-$MAJVER

--- a/build/clang/build-15.sh
+++ b/build/clang/build-15.sh
@@ -40,7 +40,10 @@ set_patchdir patches-$MAJVER
 # Using the = prefix to require the specific matching version of llvm
 BUILD_DEPENDS_IPS="=ooce/developer/llvm-$MAJVER@$VER"
 
-RUN_DEPENDS_IPS="=ooce/developer/llvm-$MAJVER@$MINVER"
+RUN_DEPENDS_IPS="
+    =ooce/developer/llvm-$MAJVER@$MINVER
+    developer/gcc$GCCVER
+"
 
 OPREFIX=$PREFIX
 PREFIX+=/llvm-$MAJVER

--- a/build/clang/build-16.sh
+++ b/build/clang/build-16.sh
@@ -40,7 +40,10 @@ set_patchdir patches-$MAJVER
 # Using the = prefix to require the specific matching version of llvm
 BUILD_DEPENDS_IPS="=ooce/developer/llvm-$MAJVER@$VER"
 
-RUN_DEPENDS_IPS="=ooce/developer/llvm-$MAJVER@$MINVER"
+RUN_DEPENDS_IPS="
+    =ooce/developer/llvm-$MAJVER@$MINVER
+    developer/gcc$GCCVER
+"
 
 OPREFIX=$PREFIX
 PREFIX+=/llvm-$MAJVER


### PR DESCRIPTION
fixes https://github.com/omniosorg/omnios-extra/issues/1352

clang is built to use gcc's runtime files as the llvm compiler-rt project does not yet build on illumos.
This means that one needs to install gcc along with clang in order to be able to link things.