### PR TITLE
Add ooce/developer/protobuf package

### DIFF
--- a/build/meta/extra-build-tools.p5m
+++ b/build/meta/extra-build-tools.p5m
@@ -16,6 +16,7 @@ depend fmri=ooce/developer/go-119 type=require
 depend fmri=ooce/developer/go-120 type=require
 depend fmri=ooce/developer/gperf type=require
 depend fmri=ooce/developer/llvm-14 type=require
+depend fmri=ooce/developer/protobuf type=require
 depend fmri=ooce/developer/yasm type=require
 depend fmri=ooce/developer/zig type=require
 depend fmri=ooce/editor/emacs type=require

--- a/build/mosh/build.sh
+++ b/build/mosh/build.sh
@@ -22,37 +22,14 @@ PKG=ooce/network/mosh
 SUMMARY="mosh - mobile shell"
 DESC="Remote terminal application that allows roaming"
 
-# The protobuf ABI changes frequently. Link mosh statically
-# to the current version.
-PBUFVER=3.21.9
-
 set_arch 64
 
+CXXFLAGS[amd64]+=" -std=c++17"
+
 init
-prep_build
-
-#####################################################################
-# Download and build a static version of protobuf
-
-save_buildenv
-
-CONFIGURE_OPTS=" --disable-shared --enable-static"
-
-build_dependency -noctf protobuf protobuf-$PBUFVER \
-    protobuf protobuf-cpp $PBUFVER
-
-restore_buildenv
-
-export protobuf_CFLAGS="-I$DEPROOT/opt/ooce/include"
-export protobuf_LIBS="-L$DEPROOT/opt/ooce/lib/amd64 -lprotobuf"
-
-# the mosh build requires the protoc protobuf compiler
-PATH+=":$DEPROOT$OOCEBIN"
-
-#####################################################################
-
 download_source $PROG $PROG $VER
 patch_source
+prep_build
 build -noctf    # C++
 make_package
 clean_up

--- a/build/obsolete/library-protobuf.p5m
+++ b/build/obsolete/library-protobuf.p5m
@@ -1,2 +1,0 @@
-set name=pkg.fmri value=pkg://$(PKGPUBLISHER)/ooce/library/protobuf@3.14.0,$(SUNOSVER)-$(PVER)
-set name=pkg.obsolete value=true

--- a/build/protobuf/build.sh
+++ b/build/protobuf/build.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2023 OmniOS Community Edition (OmniOSce) Association.
+
+. ../../lib/build.sh
+
+PROG=protobuf
+VER=25.1
+PKG=ooce/developer/protobuf
+SUMMARY="protobuf"
+DESC="Google's language-neutral, platform-neutral, extensible mechanism "
+DESC+="for serializing structured data"
+
+forgo_isaexec
+
+CONFIGURE_OPTS="
+    -DCMAKE_BUILD_TYPE=Release
+    -DCMAKE_INSTALL_PREFIX=$PREFIX
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+    -Dprotobuf_BUILD_TESTS=OFF
+"
+CONFIGURE_OPTS[i386]="-DCMAKE_INSTALL_LIBDIR=$PREFIX/${LIBDIRS[i386]}"
+CONFIGURE_OPTS[amd64]="-DCMAKE_INSTALL_LIBDIR=$PREFIX/${LIBDIRS[amd64]}"
+
+init
+clone_github_source $PROG "$GITHUB/protocolbuffers/$PROG" v$VER
+append_builddir $PROG
+run_inbuild $GIT submodule update --init --recursive
+prep_build cmake+ninja
+patch_source
+build -noctf    # C++
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/protobuf/local.mog
+++ b/build/protobuf/local.mog
@@ -1,0 +1,14 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+
+# Copyright 2023 OmniOS Community Edition (OmniOSce) Association.
+
+license LICENSE license=modified-BSD
+

--- a/doc/baseline
+++ b/doc/baseline
@@ -95,6 +95,7 @@ extra.omnios ooce/developer/llvm-17
 extra.omnios ooce/developer/ninja
 extra.omnios ooce/developer/omni
 extra.omnios ooce/developer/pkgmgr
+extra.omnios ooce/developer/protobuf
 extra.omnios ooce/developer/radare2
 extra.omnios ooce/developer/rust
 extra.omnios ooce/developer/subversion
@@ -160,7 +161,6 @@ extra.omnios ooce/library/postgresql-12
 extra.omnios ooce/library/postgresql-13
 extra.omnios ooce/library/postgresql-14
 extra.omnios ooce/library/postgresql-15
-extra.omnios ooce/library/protobuf o
 extra.omnios ooce/library/security/libsasl2
 extra.omnios ooce/library/serf
 extra.omnios ooce/library/slang

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -72,6 +72,7 @@
 | ooce/developer/ninja		| 1.11.1	| https://github.com/ninja-build/ninja/releases https://ninja-build.org/ | [omniosorg](https://github.com/omniosorg)
 | ooce/developer/omni		| github-latest	| https://github.com/omniosorg/omni/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/developer/pkgmgr		| github-latest	| https://github.com/omniosorg/pkgmgr/releases | [omniosorg](https://github.com/omniosorg)
+| ooce/developer/protobuf	| 25.1		| https://github.com/protocolbuffers/protobuf/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/developer/radare2	| 5.7.8		| https://github.com/radareorg/radare2/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/developer/rust		| 1.69.0	| https://forge.rust-lang.org/infra/other-installation-methods.html | [omniosorg](https://github.com/omniosorg)
 | ooce/developer/subversion	| 1.14.2	| https://downloads.apache.org/subversion/ | [omniosorg](https://github.com/omniosorg)
@@ -128,7 +129,6 @@
 | ooce/library/onig		| 6.9.8		| https://github.com/kkos/oniguruma/releases/ | [omniosorg](https://github.com/omniosorg)
 | ooce/library/pango		| 1.50.11	| https://download.gnome.org/sources/pango/cache.json https://ftp.gnome.org/pub/GNOME/sources/pango/ | [omniosorg](https://github.com/omniosorg)
 | ooce/library/pixman		| 0.42.2	| https://www.cairographics.org/releases/ http://www.pixman.org/ | [omniosorg](https://github.com/omniosorg)
-| ooce/library/protobuf		| 3.21.9	| https://github.com/protocolbuffers/protobuf/releases/ | Currently used solely by mosh
 | ooce/library/security/libsasl2 | 2.1.28	| https://github.com/cyrusimap/cyrus-sasl/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/library/serf		| 1.3.10 	| https://downloads.apache.org/serf/ | [omniosorg](https://github.com/omniosorg)
 | ooce/library/slang		| 2.3.3		| https://www.jedsoft.org/releases/slang/ | [omniosorg](https://github.com/omniosorg)

--- a/tools/test
+++ b/tools/test
@@ -55,9 +55,6 @@ add_target()
 			*/cyrus-imapd:*)
 				targets["ooce/library/libical"]=`pver ICALVER`
 				;;
-			*/mosh:*)
-				targets["ooce/library/protobuf"]=`pver PBUFVER`
-				;;
 			*/zadm:*)
 				targets["ooce/application/novnc"]=`pver NOVNCVER`
 				;;


### PR DESCRIPTION
Pulling this in from upstream OmniOS to provide the `protobuf` package to help with porting `deno`.
