### PR TITLE
Add asciidoctor package

### DIFF
--- a/build/asciidoctor/build.sh
+++ b/build/asciidoctor/build.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/bash
+#
+# {{{ CDDL HEADER
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+# }}}
+
+# Copyright 2024 OmniOS Community Edition (OmniOSce) Association.
+
+. ../../lib/build.sh
+
+PROG=asciidoctor
+VER=2.0.22
+PKG=ooce/text/asciidoctor
+SUMMARY="Toolchain for converting AsciiDoc to other formats"
+DESC="A fast, open source text processor and publishing toolchain, "
+DESC+="for converting AsciiDoc content to HTML 5, DocBook 5, and other formats"
+
+set_rubyver
+set_arch 64
+
+XFORM_ARGS="
+    -DPREFIX=${PREFIX#/}
+    -DPROG=$PROG
+    -DVERSION=$VER
+    -DRUBYVER=$RUBYVER
+"
+
+pre_configure() { false; }
+
+make_arch() {
+    logmsg "Building $PROG"
+    logcmd gem build $PROG.gemspec || logerr "Build failed"
+}
+
+make_install() {
+    logmsg "Installing $PROG"
+    logcmd gem install $PROG-$VER.gem \
+        --no-document \
+        --build-root $DESTDIR \
+        || logerr "Installation failed"
+}
+
+init
+download_source $PROG v$VER
+patch_source
+prep_build
+build
+make_package
+clean_up
+
+# Vim hints
+# vim:ts=4:sw=4:et:fdm=marker

--- a/build/asciidoctor/local.mog
+++ b/build/asciidoctor/local.mog
@@ -1,0 +1,19 @@
+#
+# This file and its contents are supplied under the terms of the
+# Common Development and Distribution License ("CDDL"), version 1.0.
+# You may only use this file in accordance with the terms of version
+# 1.0 of the CDDL.
+#
+# A full copy of the text of the CDDL should have accompanied this
+# source. A copy of the CDDL is also available via the Internet at
+# http://www.illumos.org/license/CDDL.
+
+# Copyright 2024 OmniOS Community Edition (OmniOSce) Association.
+
+license LICENSE license=MIT
+
+link path=$(PREFIX)/bin/$(PROG) target=../ruby-$(RUBYVER)/bin/$(PROG)
+
+link path=$(PREFIX)/share/man/man1/$(PROG).1 \
+    target=../../../ruby-$(RUBYVER)/lib/ruby/gems/$(RUBYVER).0/gems/$(PROG)-$(VERSION)/man/$(PROG).1
+

--- a/build/meta/extra-build-tools.p5m
+++ b/build/meta/extra-build-tools.p5m
@@ -57,6 +57,7 @@ depend fmri=ooce/multimedia/rav1e type=require
 depend fmri=ooce/multimedia/x264 type=require
 depend fmri=ooce/multimedia/x265 type=require
 depend fmri=ooce/runtime/ruby-30 type=require
+depend fmri=ooce/text/asciidoctor type=require
 depend fmri=ooce/text/docbook-xsl type=require
 depend fmri=system/header/header-agp type=require
 depend fmri=system/header/header-ugen type=require

--- a/doc/baseline
+++ b/doc/baseline
@@ -243,6 +243,7 @@ extra.omnios ooce/system/zrepl
 extra.omnios ooce/terminal/byobu
 extra.omnios ooce/terminal/minicom
 extra.omnios ooce/text/asciidoc
+extra.omnios ooce/text/asciidoctor
 extra.omnios ooce/text/asciinema
 extra.omnios ooce/text/datamash
 extra.omnios ooce/text/docbook-xsl

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -206,6 +206,7 @@
 | ooce/terminal/byobu		| 5.133		| https://launchpad.net/byobu/+download https://launchpad.net/byobu/ | [omniosorg](https://github.com/omniosorg)
 | ooce/terminal/minicom		| 2.8		| https://salsa.debian.org/api/v4/projects/minicom-team%2Fminicom/repository/tags/ https://salsa.debian.org/minicom-team/minicom/ | [omniosorg](https://github.com/omniosorg)
 | ooce/text/asciidoc		| 10.2.0	| https://pypi.org/project/asciidoc | [omniosorg](https://github.com/omniosorg)
+| ooce/text/asciidoctor		| 2.0.22	| https://github.com/asciidoctor/asciidoctor/releases/ | [omniosorg](https://github.com/omniosorg)
 | ooce/text/asciinema		| 2.2.0		| https://github.com/asciinema/asciinema/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/text/datamash		| 1.8		| https://ftp.gnu.org/gnu/datamash/ | [omniosorg](https://github.com/omniosorg)
 | ooce/text/hunspell		| 1.7.2		| https://github.com/hunspell/hunspell/releases | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
This is a pre-requisite for a chrony patch that updates the man page

(and may also be more generally useful for working with asciidoc)