### PR TITLE
neovim: stop build paths leaking into lua package.{path,cpath}

### DIFF
--- a/build/neovim/build.sh
+++ b/build/neovim/build.sh
@@ -17,7 +17,7 @@
 . ../../lib/build.sh
 
 PROG=neovim
-VER=0.10.0
+VER=0.10.1
 PKG=ooce/editor/neovim
 SUMMARY="Neovim"
 DESC="hyperextensible Vim-based text editor"

--- a/build/neovim/patches/illumos-support.patch
+++ b/build/neovim/patches/illumos-support.patch
@@ -13,7 +13,7 @@ diff -wpruN --no-dereference '--exclude=*.orig' a~/CMakeLists.txt a/CMakeLists.t
 +include(illumos)
 +
  #-------------------------------------------------------------------------------
- # Variables
+ # User settings
  #-------------------------------------------------------------------------------
 diff -wpruN --no-dereference '--exclude=*.orig' a~/cmake/illumos.cmake a/cmake/illumos.cmake
 --- a~/cmake/illumos.cmake	1970-01-01 00:00:00
@@ -45,7 +45,7 @@ diff -wpruN --no-dereference '--exclude=*.orig' a~/cmake.deps/CMakeLists.txt a/c
 diff -wpruN --no-dereference '--exclude=*.orig' a~/src/nvim/CMakeLists.txt a/src/nvim/CMakeLists.txt
 --- a~/src/nvim/CMakeLists.txt	1970-01-01 00:00:00
 +++ a/src/nvim/CMakeLists.txt	1970-01-01 00:00:00
-@@ -419,6 +419,9 @@ foreach(sfile ${NVIM_SOURCES})
+@@ -422,6 +422,9 @@ foreach(sfile ${NVIM_SOURCES})
    if(NOT WIN32 AND ${f} MATCHES "^(os_win_console.c)$")
      list(APPEND to_remove ${sfile})
    endif()

--- a/build/neovim/patches/libuv.patch
+++ b/build/neovim/patches/libuv.patch
@@ -1,4 +1,4 @@
-remove unecessary linking to libraries
+Remove unnecessary linking to libraries
 
 diff -wpruN --no-dereference '--exclude=*.orig' a~/cmake/FindLibuv.cmake a/cmake/FindLibuv.cmake
 --- a~/cmake/FindLibuv.cmake	1970-01-01 00:00:00

--- a/build/neovim/patches/path.patch
+++ b/build/neovim/patches/path.patch
@@ -1,0 +1,27 @@
+
+Due to the way that neovim bundles luajit, it ends up with a lua
+package.path and package.cpath including the .deps directory under
+the neovim source, which is unhelpful in the deployed package.
+
+To fix this we split the build into a build and install step and
+use the proper OOCE prefix during build. We also switch to using the
+`amalg` target here as recommended by the luajit project for any
+binary distributions.
+
+diff -wpruN --no-dereference '--exclude=*.orig' a~/cmake.deps/cmake/BuildLuajit.cmake a/cmake.deps/cmake/BuildLuajit.cmake
+--- a~/cmake.deps/cmake/BuildLuajit.cmake	1970-01-01 00:00:00
++++ a/cmake.deps/cmake/BuildLuajit.cmake	1970-01-01 00:00:00
+@@ -44,7 +44,12 @@ if(APPLE)
+ endif()
+ 
+ if(UNIX)
+-  BuildLuaJit(INSTALL_COMMAND ${BUILDCMD_UNIX}
++  BuildLuaJit(
++    BUILD_COMMAND ${BUILDCMD_UNIX}
++    CC=${DEPS_C_COMPILER} PREFIX=/opt/ooce
++    ${DEPLOYMENT_TARGET} amalg
++
++    INSTALL_COMMAND ${BUILDCMD_UNIX}
+     CC=${DEPS_C_COMPILER} PREFIX=${DEPS_INSTALL_DIR}
+     ${DEPLOYMENT_TARGET} install)
+ 

--- a/build/neovim/patches/series
+++ b/build/neovim/patches/series
@@ -2,3 +2,4 @@ libuv.patch
 link-gcc_s.patch
 illumos-support.patch
 use-system-default-tty-modes.patch
+path.patch

--- a/build/neovim/patches/use-system-default-tty-modes.patch
+++ b/build/neovim/patches/use-system-default-tty-modes.patch
@@ -4,10 +4,9 @@ Date: Fri, 31 May 2024 20:49:32 -0700
 Subject: [PATCH 2/2] XXX use system default tty modes
 
 
-diff --git a/src/nvim/os/pty_process_unix.c b/src/nvim/os/pty_process_unix.c
-index 866a1d2d5..4a37456bd 100644
---- a/src/nvim/os/pty_process_unix.c
-+++ b/src/nvim/os/pty_process_unix.c
+diff -wpruN --no-dereference '--exclude=*.orig' a~/src/nvim/os/pty_process_unix.c a/src/nvim/os/pty_process_unix.c
+--- a~/src/nvim/os/pty_process_unix.c	1970-01-01 00:00:00
++++ a/src/nvim/os/pty_process_unix.c	1970-01-01 00:00:00
 @@ -46,12 +46,6 @@
  int pty_process_spawn(PtyProcess *ptyproc)
    FUNC_ATTR_NONNULL_ALL
@@ -21,7 +20,7 @@ index 866a1d2d5..4a37456bd 100644
    int status = 0;  // zero or negative error code (libuv convention)
    Process *proc = (Process *)ptyproc;
    assert(proc->err.closed);
-@@ -59,7 +53,7 @@ int pty_process_spawn(PtyProcess *ptyproc)
+@@ -59,7 +53,7 @@ int pty_process_spawn(PtyProcess *ptypro
    ptyproc->winsize = (struct winsize){ ptyproc->height, ptyproc->width, 0, 0 };
    uv_disable_stdio_inheritance();
    int master;
@@ -30,7 +29,7 @@ index 866a1d2d5..4a37456bd 100644
  
    if (pid < 0) {
      status = -errno;
-@@ -178,63 +172,6 @@ static void init_child(PtyProcess *ptyproc)
+@@ -178,63 +172,6 @@ static void init_child(PtyProcess *ptypr
    _exit(122);  // 122 is EXEC_FAILED in the Vim source.
  }
  
@@ -94,6 +93,3 @@ index 866a1d2d5..4a37456bd 100644
  static int set_duplicating_descriptor(int fd, uv_pipe_t *pipe)
    FUNC_ATTR_NONNULL_ALL
  {
--- 
-2.40.1
-

--- a/doc/packages.md
+++ b/doc/packages.md
@@ -85,7 +85,7 @@
 | ooce/editor/helix		| 22.12		| https://github.com/helix-editor/helix/releases| [omniosorg](https://github.com/omniosorg)
 | ooce/editor/joe		| 4.6		| https://sourceforge.net/projects/joe-editor/files/JOE%20sources/ | [omniosorg](https://github.com/omniosorg)
 | ooce/editor/nano		| 7.2		| https://ftp.gnu.org/gnu/nano/ | [omniosorg](https://github.com/omniosorg)
-| ooce/editor/neovim		| 0.10.0	| https://github.com/neovim/neovim/releases | [omniosorg](https://github.com/omniosorg)
+| ooce/editor/neovim		| 0.10.1	| https://github.com/neovim/neovim/releases | [omniosorg](https://github.com/omniosorg)
 | ooce/emulator/qemu		| 8.0.2		| https://www.qemu.org/download/ | [omniosorg](https://github.com/omniosorg)
 | ooce/file/acltool		| 1.16.2	| https://github.com/ptrrkssn/acltool/releases | [Peter Eriksson](https://github.com/ptrrkssn)
 | ooce/file/lsof		| 4.95.0	| https://github.com/lsof-org/lsof/releases | [omniosorg](https://github.com/omniosorg)


### PR DESCRIPTION
Fixes #15; pulled from https://github.com/omniosorg/omnios-extra/pull/1496

This stops the embedded `luajit` in `neovim` from including build paths in the default lua `package.path` and `package.cpath` variables. nvim is usually configured to regenerate these from its own runpath, but in the event that this isn't present or something attempts to load a lua module too soon, the compiled-in paths are used which presents an error like this, clearly showing the build paths for the package are in there.

```
E5108: Error executing lua [string ":lua"]:1: module 'foo' not found:
        no field package.preload['foo']
        no file './foo.lua'
        no file '/home/andy/helios/tmp/omnios-extra/neovim-0.10.0/neovim-0.10.0/
.deps/usr/share/luajit-2.1/foo.lua'
        no file '/usr/local/share/lua/5.1/foo.lua'
        no file '/usr/local/share/lua/5.1/foo/init.lua'
        no file '/home/andy/helios/tmp/omnios-extra/neovim-0.10.0/neovim-0.10.0/
.deps/usr/share/lua/5.1/foo.lua'
        no file '/home/andy/helios/tmp/omnios-extra/neovim-0.10.0/neovim-0.10.0/
.deps/usr/share/lua/5.1/foo/init.lua'
        no file './foo.so'
        no file '/usr/local/lib/lua/5.1/foo.so'
        no file '/home/andy/helios/tmp/omnios-extra/neovim-0.10.0/neovim-0.10.0/
.deps/usr/lib/lua/5.1/foo.so'
        no file '/usr/local/lib/lua/5.1/loadall.so'
stack traceback:
        [C]: in function 'require'
        [string ":lua"]:1: in main chunk
```

Before:

```
nvim --clean

:lua print(package.path)
./?.lua;/home/andy/helios/tmp/omnios-extra/neovim-0.10.0/neovim-0.10.0/.deps/usr
/share/luajit-2.1/?.lua;/usr/local/share/lua/5.1/?.lua;/usr/local/share/lua/5.1/
?/init.lua;/home/andy/helios/tmp/omnios-extra/neovim-0.10.0/neovim-0.10.0/.deps/
usr/share/lua/5.1/?.lua;/home/andy/helios/tmp/omnios-extra/neovim-0.10.0/neovim-
0.10.0/.deps/usr/share/lua/5.1/?/init.lua

:lua print(package.cpath)
./?.so;/usr/local/lib/lua/5.1/?.so;/home/andy/helios/tmp/omnios-extra/neovim-0.1
0.0/neovim-0.10.0/.deps/usr/lib/lua/5.1/?.so;/usr/local/lib/lua/5.1/loadall.so

:q
```

After:

```
nvim --clean

:lua print(package.path)
./?.lua;/opt/ooce/share/luajit-2.1/?.lua;/usr/local/share/lua/5.1/?.lua;/usr/loc
al/share/lua/5.1/?/init.lua;/opt/ooce/share/lua/5.1/?.lua;/opt/ooce/share/lua/5.
1/?/init.lua

:lua print(package.cpath)
./?.so;/usr/local/lib/lua/5.1/?.so;/opt/ooce/lib/lua/5.1/?.so;/usr/local/lib/lua
/5.1/loadall.so

:q
```