### PR TITLE
add clangd to clang-17 package

### DIFF
--- a/build/clang/build-17.sh
+++ b/build/clang/build-17.sh
@@ -82,7 +82,8 @@ CONFIGURE_OPTS[amd64_WS]="
 pre_configure() {
     typeset arch=$1
 
-    CONFIGURE_OPTS[$arch]+="-DLLVM_EXTERNAL_CLANG_TOOLS_EXTRA_SOURCE_DIR=$TMPDIR/$EXTRACTED_SRC/../clang-tools-extra"
+    CONFIGURE_OPTS[$arch]+=" -DLLVM_EXTERNAL_CLANG_TOOLS_EXTRA_SOURCE_DIR="
+    CONFIGURE_OPTS[$arch]+="$TMPDIR/$EXTRACTED_SRC/../clang-tools-extra"
 }
 
 LDFLAGS+=" -lm"

--- a/build/clang/build-17.sh
+++ b/build/clang/build-17.sh
@@ -78,6 +78,13 @@ CONFIGURE_OPTS[amd64_WS]="
     -DLLVM_DIR=\"$PREFIX/lib/cmake/llvm\"
     -DLLVM_INCLUDE_TESTS=OFF
 "
+
+pre_configure() {
+    typeset arch=$1
+
+    CONFIGURE_OPTS[$arch]+="-DLLVM_EXTERNAL_CLANG_TOOLS_EXTRA_SOURCE_DIR=$TMPDIR/$EXTRACTED_SRC/../clang-tools-extra"
+}
+
 LDFLAGS+=" -lm"
 # we want to end up with '$ORIGIN/../lib' as runpath and not with
 # '$PREFIX/lib:$ORIGIN/../lib'; yet we need to find libLLVM during build time


### PR DESCRIPTION
Package works, `clangd` shows up at /opt/ooce/bin/clangd when the clang mediator is set to 17, and `clangd` itself seems to work well with `helix`.